### PR TITLE
Stepping down from Sous Chefs

### DIFF
--- a/chef_de_partie.tf
+++ b/chef_de_partie.tf
@@ -222,12 +222,6 @@ resource "github_team_membership" "tas50" {
   role     = "member"
 }
 
-resource "github_team_membership" "triccardi-systran" {
-  team_id  = "${github_team.Chef_de_partie.id}"
-  username = "triccardi-systran"
-  role     = "member"
-}
-
 # Repositories
 
 resource "github_team_repository" "bsdcpio" {

--- a/owners.tf
+++ b/owners.tf
@@ -37,8 +37,3 @@ resource "github_membership" "Jesse_Nelson" {
   username = "spheromak"
   role     = "admin"
 }
-
-resource "github_membership" "Thomas_Riccardi" {
-  username = "triccardi-systran"
-  role     = "admin"
-}


### PR DESCRIPTION
Since I'm not involved with Chef any more, I'd like to step down from the Sous Chefs organization.

I manually left the organization, but terraform automatically invited me back the next day, and there doesn't seem to be a way to reject an invitation.

The process should be easier than create a pull request, if possible.