### PR TITLE
tas50 can't be a maintainer as he's an org admin

### DIFF
--- a/nagios.tf
+++ b/nagios.tf
@@ -19,5 +19,5 @@ resource "github_team_membership" "nagios-maintainer-shoekstra" {
 resource "github_team_membership" "nagios-maintainer-tas50" {
   team_id  = "${github_team.nagios_team.id}"
   username = "tas50"
-  role     = "maintainer"
+  role     = "member"
 }

--- a/nrpe.tf
+++ b/nrpe.tf
@@ -19,5 +19,5 @@ resource "github_team_membership" "nrpe-maintainer-shoekstra" {
 resource "github_team_membership" "nrpe-maintainer-tas50" {
   team_id  = "${github_team.nrpe_team.id}"
   username = "tas50"
-  role     = "maintainer"
+  role     = "member"
 }


### PR DESCRIPTION

```
github_team_membership.nagios-maintainer-tas50: PUT https://api.github.com/teams/2385648/memberships/tas50: 422 User is already an admin of this organization, so they can't be promoted to a team maintainer. [{Resource:TeamMember Field:user Code:already_org_admin Message:}]
```