### PR TITLE
param `auto_init` for repo and fix race conditions for branch protection

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -20,6 +20,14 @@ resource "github_repository" "repository" {
   # creation from github api side but we also use it to determine if branch
   # protections should be enabled.
   auto_init = "${var.auto_init}"
+
+  # this is a terrible hack that is needed because of
+  # https://github.com/terraform-providers/terraform-provider-github/issues/155
+  # NOTE: that we only do this on the repo and still care about it when looking
+  # at branch protection
+  lifecycle {
+    ignore_changes = ["auto_init"]
+  }
 }
 
 resource "github_branch_protection" "repository_master" {
@@ -34,8 +42,8 @@ resource "github_branch_protection" "repository_master" {
 
   # when a repo is being initialized/created you can run into race conditions by adding an explicit depends we force the repo to be created before it attempts to add branch protection
   depends_on = [
-  "github_repository.repository",
-]
+    "github_repository.repository",
+  ]
 
   required_status_checks {
     strict   = "${var.require_ci_pass}"

--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -61,11 +61,11 @@ resource "github_branch_protection" "repository_master" {
 resource "github_team_repository" "repository_everyone" {
   team_id    = "${var.chef_de_partie}"
   repository = "${github_repository.repository.name}"
-  permission = "${var.everyone_permission}"
+  permission = "${var.archived ? "pull" : var.everyone_permission}"
 }
 
 resource "github_team_repository" "restricted_access" {
   team_id    = "${var.cookbook_team}"
   repository = "${github_repository.repository.name}"
-  permission = "${var.team_permission}"
+  permission = "${var.archived ? "pull" : var.team_permission}"
 }

--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -13,12 +13,29 @@ resource "github_repository" "repository" {
   has_downloads      = false
   archived           = "${var.archived}"
   topics             = "${local.topics}"
+
+  # this automatically creates a commit and pushes to master and is needed
+  # because your can't add branch protection for an uninitialized repo
+  # since the branch will not exist yet. It is only relevant during repo
+  # creation from github api side but we also use it to determine if branch
+  # protections should be enabled.
+  auto_init = "${var.auto_init}"
 }
 
 resource "github_branch_protection" "repository_master" {
+  # this is a bit of a hack to allow people to create repositories uninitialized
+  # and then add branch protection later. The use cases are mostly around needing
+  # to create "forked" private repositories
+  count = "${var.auto_init}"
+
   repository     = "${var.name}"
   branch         = "master"
   enforce_admins = "${var.enforce_admins}"
+
+  # when a repo is being initialized/created you can run into race conditions by adding an explicit depends we force the repo to be created before it attempts to add branch protection
+  depends_on = [
+  "github_repository.repository",
+]
 
   required_status_checks {
     strict   = "${var.require_ci_pass}"

--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -78,3 +78,20 @@ variable "additional_topics" {
   type    = "list"
   default = []
 }
+
+variable "auto_init" {
+  default = true
+  description = <<DESCRIPTION
+  This is an option that initializes the repo, it defaults to true. If it is set
+  to false then it will not enable branch protection. The only use cases where
+  you might want this is to create a project based on another project such as
+  needing to use the import api or doing a bare clone. This setting only really
+  applies (from github api perspective) when the repo is initially created,
+  however as we can only set up branch protection if the repo has been initialized
+  with the master branch we use it as well to control branch protections being
+  enabled. If you need to handle one of these edgecases you should set `auto_init`
+  to false initially so the repo can be created. After its been created and
+  commits/hostory migrated (be it bare clone or import api) you would then set
+  this to true which should enable branch protections.
+DESCRIPTION
+}


### PR DESCRIPTION
## Description

Basically when you create a new repo you can have a race condition where it wants to create the branch protection. The problem is that you have two dependencies:
- the repo itself
- the branch to be protected needs to exist

By adding an explicit depends we can ensure that only after the repo resource has been run will it attempt to setup branch protections.

Also in the case of wanting to create a repository and copy the history of another project in you can specify `auto_init` and it will not attempt to initialize the repo with a commit or setup protection. After copying the history you can flip `auto_init` to `true` which will flip the branch protection on without creating any commits.

Signed-off-by: Ben Abrams <me@benabrams.it>

Additional scope after resurrecting this pull request:
- check if a repo has been archived and if so set `pull` permission to prevent terraform from thinking that permissions need to be updated. Otherwise once a repository has been archived it would either require updating those vars to pull but it seems easier to just check the condition and act in the users best interest.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
~- [ ] New functionality includes testing.~
~- [ ] New functionality has been documented in the README if applicable~
