### PR TITLE
Update the haproxy required status checks

### DIFF
--- a/haproxy.tf
+++ b/haproxy.tf
@@ -5,6 +5,7 @@ module "haproxy" {
   chef_de_partie             = "${github_team.Chef_de_partie.id}"
   enforce_admins             = true
   require_code_owner_reviews = true
+  status_checks              = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "haproxy" {


### PR DESCRIPTION
## Description

The status check name changed from lint to delivery. This sets the variable used [here](https://github.com/sous-chefs/terraform-github-org/blob/master/modules/repository/main.tf#L50) to override the default set [here](https://github.com/sous-chefs/terraform-github-org/blob/master/modules/repository/variables.tf#L35)

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
