### PR TITLE
Set Zabbix to use delivery status checks

### DIFF
--- a/zabbix-agent.tf
+++ b/zabbix-agent.tf
@@ -2,6 +2,7 @@ module "zabbix-agent" {
   source        = "modules/repository"
   name          = "zabbix-agent"
   cookbook_team = "${github_team.zabbix-agent.id}"
+  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "zabbix-agent" {


### PR DESCRIPTION
## Description

Forces zabbix to use delivery and not lint status checks

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
