### PR TITLE
Changed default ci task for control_groups to be delivery

### DIFF
--- a/control_groups.tf
+++ b/control_groups.tf
@@ -3,6 +3,7 @@ module "control_groups" {
   name                       = "control_groups"
   cookbook_team              = "${github_team.control_groups.id}"
   require_code_owner_reviews = true
+  status_checks              = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "control_groups" {


### PR DESCRIPTION
## Description

Hi, within PR https://github.com/sous-chefs/control_groups/pull/23 I'm proposing to use your circle delivery task (via orb v2) for linting. 

@JohnRoesler suggested this was right course of action

### Issues Resolved

This started as I noticed this PR (https://github.com/sous-chefs/control_groups/pull/22) was failing due to the chef license changes.

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] ~~New functionality includes testing.~~
- [ ] ~~New functionality has been documented in the README if applicable~~
