### PR TITLE
Add self to java team

### DIFF
--- a/java.tf
+++ b/java.tf
@@ -22,3 +22,9 @@ resource "github_team_membership" "java-maintainer-2" {
   username = "duncaan"
   role     = "maintainer"
 }
+  
+resource "github_team_membership" "java-maintainer-3" {
+  team_id  = "${github_team.java.id}"
+  username = "majormoses"
+  role     = "member"
+}


### PR DESCRIPTION
I have been maintaining the java cookbook for a while and have supermarket access based on https://github.com/sous-chefs/java/pull/552#pullrequestreview-262203939 I wanted to ensure that we did not add further blockers for merging and releasing.

## Description

Add self to java team

### Issues Resolved

https://github.com/sous-chefs/java/pull/552#pullrequestreview-262203939

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
