### PR TITLE
Use Delivery as default status check

### DIFF
--- a/apache2.tf
+++ b/apache2.tf
@@ -3,7 +3,6 @@ module "apache2" {
   name                       = "apache2"
   cookbook_team              = github_team.apache2.id
   require_code_owner_reviews = true
-  status_checks              = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "apache2" {

--- a/aptly.tf
+++ b/aptly.tf
@@ -2,6 +2,7 @@ module "aptly" {
   source        = "./modules/repository"
   name          = "aptly"
   cookbook_team = github_team.aptly.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "aptly" {

--- a/bsdcpio.tf
+++ b/bsdcpio.tf
@@ -2,6 +2,7 @@ module "bsdcpio" {
   source        = "./modules/repository"
   name          = "bsdcpio"
   cookbook_team = github_team.bsdcpio.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "bsdcpio" {

--- a/confluence.tf
+++ b/confluence.tf
@@ -3,6 +3,7 @@ module "confluence" {
   name          = "confluence"
   description   = "Sous Chefs confluence Cookbook"
   cookbook_team = github_team.confluence.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "confluence" {

--- a/consul.tf
+++ b/consul.tf
@@ -2,7 +2,6 @@ module "consul" {
   source        = "./modules/repository"
   name          = "consul"
   cookbook_team = github_team.consul.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "consul" {

--- a/control_groups.tf
+++ b/control_groups.tf
@@ -3,7 +3,6 @@ module "control_groups" {
   name                       = "control_groups"
   cookbook_team              = github_team.control_groups.id
   require_code_owner_reviews = true
-  status_checks              = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "control_groups" {

--- a/dhcp.tf
+++ b/dhcp.tf
@@ -2,7 +2,6 @@ module "dhcp" {
   source        = "./modules/repository"
   name          = "dhcp"
   cookbook_team = github_team.dhcp.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "dhcp" {

--- a/dnsmasq.tf
+++ b/dnsmasq.tf
@@ -2,6 +2,7 @@ module "dnsmasq" {
   source        = "./modules/repository"
   name          = "dnsmasq"
   cookbook_team = github_team.dnsmasq.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "dnsmasq" {

--- a/filesystem.tf
+++ b/filesystem.tf
@@ -2,6 +2,7 @@ module "filesystem" {
   source        = "./modules/repository"
   name          = "filesystem"
   cookbook_team = github_team.filesystem.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "filesystem" {

--- a/gpg.tf
+++ b/gpg.tf
@@ -2,6 +2,7 @@ module "gpg" {
   source        = "./modules/repository"
   name          = "gpg"
   cookbook_team = github_team.gpg.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "gpg" {

--- a/grafana.tf
+++ b/grafana.tf
@@ -3,7 +3,6 @@ module "grafana" {
   name                       = "grafana"
   cookbook_team              = github_team.grafana.id
   require_code_owner_reviews = true
-  status_checks              = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "grafana" {

--- a/graphite.tf
+++ b/graphite.tf
@@ -4,6 +4,7 @@ module "graphite" {
   cookbook_team              = github_team.graphite.id
   enforce_admins             = true
   require_code_owner_reviews = true
+  status_checks              = ["ci/circleci: lint"]
 }
 
 resource "github_team" "graphite" {

--- a/haproxy.tf
+++ b/haproxy.tf
@@ -3,7 +3,6 @@ module "haproxy" {
   name           = "haproxy"
   cookbook_team  = github_team.haproxy.id
   enforce_admins = true
-  status_checks  = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "haproxy" {

--- a/java.tf
+++ b/java.tf
@@ -2,7 +2,6 @@ module "java" {
   source        = "./modules/repository"
   name          = "java"
   cookbook_team = github_team.java.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "java" {

--- a/kafka.tf
+++ b/kafka.tf
@@ -2,7 +2,6 @@ module "kafka" {
   source        = "./modules/repository"
   name          = "kafka"
   cookbook_team = github_team.kafka.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "kafka" {

--- a/keepalived.tf
+++ b/keepalived.tf
@@ -2,7 +2,6 @@ module "keepalived" {
   source        = "./modules/repository"
   name          = "keepalived"
   cookbook_team = github_team.keepalived.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "keepalived" {

--- a/kismet.tf
+++ b/kismet.tf
@@ -2,6 +2,7 @@ module "kismet" {
   source        = "./modules/repository"
   name          = "kismet"
   cookbook_team = github_team.kismet.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "kismet" {

--- a/language-chef.tf
+++ b/language-chef.tf
@@ -2,9 +2,9 @@ module "language-chef" {
   source        = "./modules/repository"
   name          = "language-chef"
   cookbook_team = github_team.language-chef.id
-
-  description  = "Development repository for the language-chef plugin for the Atom text editor"
-  homepage_url = "https://atom.io/packages/language-chef"
+  status_checks = ["ci/circleci: lint"]
+  description   = "Development repository for the language-chef plugin for the Atom text editor"
+  homepage_url  = "https://atom.io/packages/language-chef"
 }
 
 resource "github_team" "language-chef" {

--- a/line.tf
+++ b/line.tf
@@ -4,7 +4,6 @@ module "line" {
   description   = "Development repository for the line cookbook"
   homepage_url  = "https://supermarket.chef.io/cookbooks/line"
   cookbook_team = github_team.line.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "line" {

--- a/mariadb.tf
+++ b/mariadb.tf
@@ -3,6 +3,7 @@ module "mariadb" {
   name            = "mariadb"
   cookbook_team   = github_team.mariadb.id
   team_permission = "admin"
+  status_checks   = ["ci/circleci: lint"]
 }
 
 resource "github_team" "mariadb" {

--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -28,7 +28,7 @@ variable "require_ci_pass" {
 
 variable "status_checks" {
   type    = "list"
-  default = ["ci/circleci: lint"]
+  default = ["ci/circleci: delivery"]
 }
 
 variable "has_wiki" {

--- a/mongodb.tf
+++ b/mongodb.tf
@@ -2,8 +2,8 @@ module "mongodb" {
   source        = "./modules/repository"
   name          = "mongodb"
   cookbook_team = github_team.mongodb.id
-
-  homepage_url = "https://supermarket.chef.io/cookbooks/sc-mongodb"
+  status_checks = ["ci/circleci: lint"]
+  homepage_url  = "https://supermarket.chef.io/cookbooks/sc-mongodb"
 }
 
 resource "github_team" "mongodb" {

--- a/mysql.tf
+++ b/mysql.tf
@@ -3,6 +3,7 @@ module "mysql" {
   name          = "mysql"
   description   = "Sous Chefs MySQL Cookbook"
   cookbook_team = github_team.mysql.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "mysql" {

--- a/nagios.tf
+++ b/nagios.tf
@@ -2,8 +2,8 @@ module "nagios" {
   source        = "./modules/repository"
   name          = "nagios"
   cookbook_team = github_team.nagios.id
-
-  has_wiki = true
+  status_checks = ["ci/circleci: lint"]
+  has_wiki      = true
 }
 
 resource "github_team" "nagios" {

--- a/nano.tf
+++ b/nano.tf
@@ -2,7 +2,6 @@ module "nano" {
   source        = "./modules/repository"
   name          = "nano"
   cookbook_team = github_team.nano.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "nano" {

--- a/nexus.tf
+++ b/nexus.tf
@@ -3,6 +3,7 @@ module "nexus" {
   name                       = "nexus"
   cookbook_team              = github_team.nexus.id
   require_code_owner_reviews = true
+  status_checks              = ["ci/circleci: lint"]
 }
 
 resource "github_team" "nexus" {

--- a/nginx.tf
+++ b/nginx.tf
@@ -2,8 +2,6 @@ module "nginx" {
   source        = "./modules/repository"
   name          = "nginx"
   cookbook_team = github_team.nginx.id
-
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "nginx" {

--- a/nginx_simplecgi.tf
+++ b/nginx_simplecgi.tf
@@ -2,6 +2,7 @@ module "nginx_simplecgi" {
   source        = "./modules/repository"
   name          = "nginx_simplecgi"
   cookbook_team = github_team.nginx_simplecgi.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "nginx_simplecgi" {

--- a/npm_lazy.tf
+++ b/npm_lazy.tf
@@ -2,6 +2,7 @@ module "npm_lazy" {
   source        = "./modules/repository"
   name          = "npm_lazy"
   cookbook_team = github_team.npm_lazy.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "npm_lazy" {

--- a/nrpe.tf
+++ b/nrpe.tf
@@ -3,6 +3,7 @@ module "nrpe" {
   name          = "nrpe"
   description   = "Chef cookbook to install Nagios NRPE client"
   cookbook_team = github_team.nrpe.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "nrpe" {

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -4,7 +4,6 @@ module "openvpn" {
   cookbook_team              = github_team.openvpn.id
   enforce_admins             = true
   require_code_owner_reviews = true
-  status_checks              = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "openvpn" {

--- a/orbs.tf
+++ b/orbs.tf
@@ -3,7 +3,7 @@ module "orbs" {
   name          = "orbs"
   cookbook_team = github_team.orbs.id
   status_checks = ["ci/circleci: lint"]
-  description = "The source code for orbs published by Sous-Chefs https://circleci.com/orbs/registry"
+  description   = "The source code for orbs published by Sous-Chefs https://circleci.com/orbs/registry"
 }
 
 resource "github_team" "orbs" {

--- a/orbs.tf
+++ b/orbs.tf
@@ -2,7 +2,7 @@ module "orbs" {
   source        = "./modules/repository"
   name          = "orbs"
   cookbook_team = github_team.orbs.id
-
+  status_checks = ["ci/circleci: lint"]
   description = "The source code for orbs published by Sous-Chefs https://circleci.com/orbs/registry"
 }
 

--- a/ossec.tf
+++ b/ossec.tf
@@ -2,6 +2,7 @@ module "ossec" {
   source        = "./modules/repository"
   name          = "ossec"
   cookbook_team = github_team.ossec.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "ossec" {

--- a/passenger_apache2.tf
+++ b/passenger_apache2.tf
@@ -2,7 +2,6 @@ module "passenger_apache2" {
   source        = "./modules/repository"
   name          = "passenger_apache2"
   cookbook_team = github_team.passenger_apache2.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "passenger_apache2" {

--- a/percona.tf
+++ b/percona.tf
@@ -2,8 +2,6 @@ module "percona" {
   source        = "./modules/repository"
   name          = "percona"
   cookbook_team = github_team.percona.id
-
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "percona" {

--- a/php.tf
+++ b/php.tf
@@ -2,6 +2,7 @@ module "php" {
   source        = "./modules/repository"
   name          = "php"
   cookbook_team = github_team.php.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "php" {

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -2,6 +2,7 @@ module "postgresql" {
   source        = "./modules/repository"
   name          = "postgresql"
   cookbook_team = github_team.postgresql.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "postgresql" {

--- a/pulledpork.tf
+++ b/pulledpork.tf
@@ -2,6 +2,7 @@ module "pulledpork" {
   source        = "./modules/repository"
   name          = "pulledpork"
   cookbook_team = github_team.pulledpork.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "pulledpork" {

--- a/redisio.tf
+++ b/redisio.tf
@@ -3,7 +3,6 @@ module "redisio" {
   name          = "redisio"
   description   = "Development repository for the redisio cookbook"
   cookbook_team = github_team.redisio.id
-  status_checks = ["ci/circleci: delivery", "ci/circleci: lint-markdown", "ci/circleci: lint-yaml"]
 }
 
 resource "github_team" "redisio" {

--- a/reprepro.tf
+++ b/reprepro.tf
@@ -2,6 +2,7 @@ module "reprepro" {
   source        = "./modules/repository"
   name          = "reprepro"
   cookbook_team = github_team.reprepro.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "reprepro" {

--- a/ruby_build.tf
+++ b/ruby_build.tf
@@ -2,6 +2,7 @@ module "ruby_build" {
   source        = "./modules/repository"
   name          = "ruby_build"
   cookbook_team = github_team.ruby_build.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "ruby_build" {

--- a/ruby_rbenv.tf
+++ b/ruby_rbenv.tf
@@ -2,6 +2,7 @@ module "ruby_rbenv" {
   source        = "./modules/repository"
   name          = "ruby_rbenv"
   cookbook_team = github_team.ruby_rbenv.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "ruby_rbenv" {

--- a/rundeck.tf
+++ b/rundeck.tf
@@ -5,7 +5,6 @@ module "rundeck" {
   cookbook_team              = github_team.rundeck.id
   enforce_admins             = true
   require_code_owner_reviews = true
-  status_checks              = ["ci/circleci: delivery", "ci/circleci: lint-markdown", "ci/circleci: lint-yaml"]
 }
 
 resource "github_team" "rundeck" {

--- a/rvm.tf
+++ b/rvm.tf
@@ -2,6 +2,7 @@ module "rvm" {
   source        = "./modules/repository"
   name          = "rvm"
   cookbook_team = github_team.rvm.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "rvm" {

--- a/samba.tf
+++ b/samba.tf
@@ -2,6 +2,7 @@ module "samba" {
   source        = "./modules/repository"
   name          = "samba"
   cookbook_team = github_team.samba.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "samba" {

--- a/selinuxpolicy.tf
+++ b/selinuxpolicy.tf
@@ -3,7 +3,6 @@ module "selinuxpolicy" {
   name                       = "selinux_policy"
   cookbook_team              = github_team.selinux_policy.id
   require_code_owner_reviews = true
-  status_checks              = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "selinux_policy" {

--- a/sensors.tf
+++ b/sensors.tf
@@ -2,7 +2,6 @@ module "sensors" {
   source        = "./modules/repository"
   name          = "sensors"
   cookbook_team = github_team.sensors.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "sensors" {

--- a/smartmontools.tf
+++ b/smartmontools.tf
@@ -2,7 +2,6 @@ module "smartmontools" {
   source        = "./modules/repository"
   name          = "smartmontools"
   cookbook_team = github_team.smartmontools.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "smartmontools" {

--- a/snort.tf
+++ b/snort.tf
@@ -2,7 +2,6 @@ module "snort" {
   source        = "./modules/repository"
   name          = "snort"
   cookbook_team = github_team.snort.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "snort" {

--- a/squid.tf
+++ b/squid.tf
@@ -2,8 +2,6 @@ module "squid" {
   source        = "./modules/repository"
   name          = "squid"
   cookbook_team = github_team.squid.id
-
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "squid" {

--- a/unbound.tf
+++ b/unbound.tf
@@ -2,7 +2,6 @@ module "unbound" {
   source        = "./modules/repository"
   name          = "unbound"
   cookbook_team = github_team.unbound.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "unbound" {

--- a/unifi.tf
+++ b/unifi.tf
@@ -2,7 +2,6 @@ module "unifi" {
   source        = "./modules/repository"
   name          = "unifi"
   cookbook_team = github_team.unifi.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "unifi" {

--- a/vagrant.tf
+++ b/vagrant.tf
@@ -2,7 +2,6 @@ module "vagrant" {
   source        = "./modules/repository"
   name          = "vagrant"
   cookbook_team = github_team.vagrant.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "vagrant" {

--- a/varnish.tf
+++ b/varnish.tf
@@ -2,6 +2,7 @@ module "varnish" {
   source        = "./modules/repository"
   name          = "varnish"
   cookbook_team = github_team.varnish.id
+  status_checks = ["ci/circleci: lint"]
 }
 
 resource "github_team" "varnish" {

--- a/vault.tf
+++ b/vault.tf
@@ -2,7 +2,6 @@ module "vault" {
   source        = "./modules/repository"
   name          = "vault"
   cookbook_team = github_team.vault.id
-  status_checks = ["ci/circleci: delivery"]
   description   = "Development repository for the hashicorp-vault cookbook"
 }
 

--- a/vscode.tf
+++ b/vscode.tf
@@ -3,7 +3,6 @@ module "vscode" {
   name                       = "vscode"
   cookbook_team              = github_team.vscode.id
   require_code_owner_reviews = true
-  status_checks              = ["ci/circleci: delivery"]
   description                = "Development repository for the sc_vscode cookbook"
 }
 

--- a/zabbix-agent.tf
+++ b/zabbix-agent.tf
@@ -2,7 +2,6 @@ module "zabbix-agent" {
   source        = "./modules/repository"
   name          = "zabbix-agent"
   cookbook_team = github_team.zabbix-agent.id
-  status_checks = ["ci/circleci: delivery"]
 }
 
 resource "github_team" "zabbix-agent" {


### PR DESCRIPTION
## Description

This commit will flip everything to use delivery as default
if it was still using lint it has been set except for sc-nxlog and atom which are ready for delivery

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
