### PR TITLE
create team and repo for chef-pyenv

### DIFF
--- a/chef-pyenv.tf
+++ b/chef-pyenv.tf
@@ -1,0 +1,17 @@
+module "ruby_rbenv" {
+  source        = "./modules/repository"
+  name          = "chef-pyenv"
+  cookbook_team = github_team.chef-pyenv.id
+}
+
+resource "github_team" "chef-pyenv" {
+  name        = "chef-pyenv"
+  description = "Pyenv Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "chef-pyenv-maintainer-1" {
+  team_id  = github_team.chef-pyenv.id
+  username = "darwin67"
+  role     = "maintainer"
+}


### PR DESCRIPTION
## Description

Create the team and repo for chef-pyenv.

I wasn't aware of this so I already transferred the repo and created the team by hand so you will need to import the current status into terraform.

### Issues Resolved

N/A