### PR TITLE
delete_branch_on_merge

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -3,17 +3,17 @@ resource "github_repository" "repository" {
   description  = local.description
   homepage_url = local.homepage_url
 
-  private                 = false
-  has_issues              = true
-  has_wiki                = var.has_wiki
-  has_projects            = var.has_projects
-  allow_merge_commit      = true
-  allow_squash_merge      = true
-  allow_rebase_merge      = true
-  delete_branch_on_merge  = true
-  has_downloads           = false
-  archived                = var.archived
-  topics                  = local.topics
+  private                = false
+  has_issues             = true
+  has_wiki               = var.has_wiki
+  has_projects           = var.has_projects
+  allow_merge_commit     = true
+  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  delete_branch_on_merge = true
+  has_downloads          = false
+  archived               = var.archived
+  topics                 = local.topics
 
   # this automatically creates a commit and pushes to master and is needed
   # because your can't add branch protection for an uninitialized repo

--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -3,16 +3,17 @@ resource "github_repository" "repository" {
   description  = local.description
   homepage_url = local.homepage_url
 
-  private            = false
-  has_issues         = true
-  has_wiki           = var.has_wiki
-  has_projects       = var.has_projects
-  allow_merge_commit = true
-  allow_squash_merge = true
-  allow_rebase_merge = true
-  has_downloads      = false
-  archived           = var.archived
-  topics             = local.topics
+  private                 = false
+  has_issues              = true
+  has_wiki                = var.has_wiki
+  has_projects            = var.has_projects
+  allow_merge_commit      = true
+  allow_squash_merge      = true
+  allow_rebase_merge      = true
+  delete_branch_on_merge  = true
+  has_downloads           = false
+  archived                = var.archived
+  topics                  = local.topics
 
   # this automatically creates a commit and pushes to master and is needed
   # because your can't add branch protection for an uninitialized repo


### PR DESCRIPTION
## Description

Enable the `delete_branch_on_merge` functionality for github repos. 
Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
