### PR TITLE
Add the chef_ca and fileutils maintainers groups

### DIFF
--- a/atom.tf
+++ b/atom.tf
@@ -16,3 +16,9 @@ resource "github_team_membership" "atom-maintainer-1" {
   role     = "maintainer"
 }
 
+resource "github_team_membership" "atom-maintainer-2' {
+  team_id  = github_team.atom.id
+  username = "MarkGibbons"
+  role     = "maintainer"
+}
+

--- a/chef_ca.tf
+++ b/chef_ca.tf
@@ -1,0 +1,17 @@
+module "chef_ca" {
+  source        = "./modules/repository"
+  name          = "chef_ca"
+  cookbook_team = github_team.chef_ca.id
+}
+
+resource "github_team" "chef_ca" {
+  name        = "chef_ca"
+  description = "chef_ca Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "chef_ca-maintainer-1" {
+  team_id  = github_team.chef_ca.id
+  username = "MarkGibbons"
+  role     = "maintainer"
+}

--- a/dnsmasq.tf
+++ b/dnsmasq.tf
@@ -16,3 +16,8 @@ resource "github_team_membership" "dnsmasq-maintainer-1" {
   role     = "maintainer"
 }
 
+resource "github_team_membership" "dnsmasq-maintainer-1" {
+  team_id  = github_team.dnsmasq.id
+  username = "MarkGibbons"
+  role     = "maintainer"
+}

--- a/fileutils.tf
+++ b/fileutils.tf
@@ -1,0 +1,17 @@
+module "fileutils" {
+  source        = "./modules/repository"
+  name          = "fileutils"
+  cookbook_team = github_team.fileutils.id
+}
+
+resource "github_team" "fileutils" {
+  name        = "fileutils"
+  description = "fileutils Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "fileutils-maintainer-1" {
+  team_id  = github_team.fileutils.id
+  username = "MarkGibbons"
+  role     = "maintainer"
+}

--- a/golang.tf
+++ b/golang.tf
@@ -21,3 +21,9 @@ resource "github_team_membership" "golang-maintainer-2" {
   username = "JohnRoesler"
   role     = "maintainer"
 }
+
+resource "github_team_membership" "golang-maintainer-3" {
+  team_id  = github_team.golang.id
+  username = "MarkGibbons"
+  role     = "maintainer"
+}

--- a/nginx.tf
+++ b/nginx.tf
@@ -16,3 +16,9 @@ resource "github_team_membership" "nginx-maintainer-1" {
   role     = "maintainer"
 }
 
+resource "github_team_membership" "nginx-maintainer-2" {
+  team_id  = github_team.nginx.id
+  username = "MarkGibbons"
+  role     = "maintainer"
+}
+


### PR DESCRIPTION
Add Mark Gibbons as a maintainer for atom, dnsmasq, goland and nginx

## Description

Add 2 new cookbooks.  Line up maintainer access for a few cookbooks I'm qualified to comment and work on.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
