### PR TITLE
Add all new cookbooks into TF

### DIFF
--- a/cpu.tf
+++ b/cpu.tf
@@ -1,0 +1,17 @@
+module "cpu" {
+  source        = "./modules/repository"
+  name          = "cpu"
+  cookbook_team = github_team.cpu.id
+}
+
+resource "github_team" "cpu" {
+  name        = "cpu"
+  description = "cpu Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "cpu-maintainer-1" {
+  team_id  = github_team.cpu.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/daemontools.tf
+++ b/daemontools.tf
@@ -1,17 +1,17 @@
-#module "daemontools" {
-#  source        = "./modules/repository"
-#  name          = "daemontools"
-#  cookbook_team = github_team.daemontools.id
-#}
-#
-#resource "github_team" "daemontools" {
-#  name        = "daemontools"
-#  description = "daemontools Cookbook Maintainers"
-#  privacy     = "closed"
-#}
-#
-#resource "github_team_membership" "daemontools-maintainer-1" {
-#  team_id  = github_team.daemontools.id
-#  username = "limitusus"
-#  role     = "maintainer"
-#}
+module "daemontools" {
+  source        = "./modules/repository"
+  name          = "daemontools"
+  cookbook_team = github_team.daemontools.id
+}
+
+resource "github_team" "daemontools" {
+  name        = "daemontools"
+  description = "daemontools Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "daemontools-maintainer-1" {
+  team_id  = github_team.daemontools.id
+  username = "limitusus"
+  role     = "maintainer"
+}

--- a/docker-engine.tf
+++ b/docker-engine.tf
@@ -1,0 +1,17 @@
+module "docker-engine" {
+  source        = "./modules/repository"
+  name          = "docker-engine"
+  cookbook_team = github_team.docker-engine.id
+}
+
+resource "github_team" "docker-engine" {
+  name        = "docker-engine"
+  description = "docker-engine Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "docker-engine-maintainer-1" {
+  team_id  = github_team.docker-engine.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/foreman.tf
+++ b/foreman.tf
@@ -1,0 +1,17 @@
+module "foreman" {
+  source        = "./modules/repository"
+  name          = "foreman"
+  cookbook_team = github_team.foreman.id
+}
+
+resource "github_team" "foreman" {
+  name        = "foreman"
+  description = "foreman Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "foreman-maintainer-1" {
+  team_id  = github_team.foreman.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/htpasswd.tf
+++ b/htpasswd.tf
@@ -1,0 +1,17 @@
+module "htpasswd" {
+  source        = "./modules/repository"
+  name          = "htpasswd"
+  cookbook_team = github_team.htpasswd.id
+}
+
+resource "github_team" "htpasswd" {
+  name        = "htpasswd"
+  description = "htpasswd Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "htpasswd-maintainer-1" {
+  team_id  = github_team.htpasswd.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/locales.tf
+++ b/locales.tf
@@ -1,0 +1,17 @@
+module "locales" {
+  source        = "./modules/repository"
+  name          = "locales"
+  cookbook_team = github_team.locales.id
+}
+
+resource "github_team" "locales" {
+  name        = "locales"
+  description = "locales Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "locales-maintainer-1" {
+  team_id  = github_team.locales.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/modules.tf
+++ b/modules.tf
@@ -1,0 +1,17 @@
+module "modules" {
+  source        = "./modules/repository"
+  name          = "modules"
+  cookbook_team = github_team.modules.id
+}
+
+resource "github_team" "modules" {
+  name        = "modules"
+  description = "modules Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "modules-maintainer-1" {
+  team_id  = github_team.modules.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/network_interfaces.tf
+++ b/network_interfaces.tf
@@ -1,0 +1,17 @@
+module "network_interfaces" {
+  source        = "./modules/repository"
+  name          = "network_interfaces"
+  cookbook_team = github_team.network_interfaces.id
+}
+
+resource "github_team" "network_interfaces" {
+  name        = "network_interfaces"
+  description = "network_interfaces Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "network_interfaces-maintainer-1" {
+  team_id  = github_team.network_interfaces.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/nodejs.tf
+++ b/nodejs.tf
@@ -1,0 +1,17 @@
+module "nodejs" {
+  source        = "./modules/repository"
+  name          = "nodejs"
+  cookbook_team = github_team.nodejs.id
+}
+
+resource "github_team" "nodejs" {
+  name        = "nodejs"
+  description = "nodejs Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "nodejs-maintainer-1" {
+  team_id  = github_team.nodejs.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/traefik.tf
+++ b/traefik.tf
@@ -1,0 +1,17 @@
+module "traefik" {
+  source        = "./modules/repository"
+  name          = "traefik"
+  cookbook_team = github_team.traefik.id
+}
+
+resource "github_team" "traefik" {
+  name        = "traefik"
+  description = "traefik Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "traefik-maintainer-1" {
+  team_id  = github_team.traefik.id
+  username = "tas50"
+  role     = "maintainer"
+}

--- a/winlogbeats.tf
+++ b/winlogbeats.tf
@@ -1,0 +1,17 @@
+module "winlogbeats" {
+  source        = "./modules/repository"
+  name          = "winlogbeats"
+  cookbook_team = github_team.winlogbeats.id
+}
+
+resource "github_team" "winlogbeats" {
+  name        = "winlogbeats"
+  description = "winlogbeats Cookbook Maintainers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "winlogbeats-maintainer-1" {
+  team_id  = github_team.winlogbeats.id
+  username = "tas50"
+  role     = "maintainer"
+}


### PR DESCRIPTION
## Description

Adds the following cookbooks to Terraform:
- cpu
- daemontools
- docker-engine
- foreman
- htpasswd
- locales
- modules
- network_interfaces
- nodejs
- traefik
- winlogbeats

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Issues Resolved

N/A

### Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
