### PR TITLE
Feat: Add Default hacktoberfest topic.

### DIFF
--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -66,7 +66,7 @@ variable "archived" {
 }
 
 locals {
-  default_topics = ["chef", "${replace(replace(var.name, "_", "-"), ".", "")}", "terraform-managed"]
+  default_topics = ["chef", "${replace(replace(var.name, "_", "-"), ".", "")}", "terraform-managed", "hacktoberfest"]
   topics         = concat(local.default_topics, var.additional_topics)
 }
 


### PR DESCRIPTION
## Description

Adds a default `hacktoberfest` topic to all repos. This alllows PR's sent to a repo to be counted towards hacktoberfest.

### Issues Resolved

None

### Check List
- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
