### PR TITLE
Change the target branch of actionshub/terraform-lint to main.

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Check out code
       uses: actions/checkout@master
     - name: Lint Terraform
-      uses: actionshub/terraform-lint@master
+      uses: actionshub/terraform-lint@main


### PR DESCRIPTION
The default branch has changed and a warning is now shown on master.

## Description

Change the target branch of actionshub/terraform-lint to main.

### Issues Resolved

Resolves the warning 
```
 Warning: Github Action: actionshub/terraform-lint has migrated to the main branch as default, the master branch will be removed
```
as seen in https://github.com/sous-chefs/terraform-github-org/pull/293/checks?check_run_id=1483148990

### Check List
- [x] All tests pass.